### PR TITLE
use tilde notation when referencing phpspec from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "phpspec/phpspec": "2.0.*"
+        "phpspec/phpspec": "~2.0"
     },
     "require-dev": {
         "behat/behat": "2.4.*@stable",


### PR DESCRIPTION
Allow "last significant release" of PHPSpec to be used with this extension.