### PR TITLE
Test doubles injected after data provider arguments

### DIFF
--- a/features/use_data_providers_in_examples.feature
+++ b/features/use_data_providers_in_examples.feature
@@ -71,3 +71,65 @@ class String
     And I should see "✔ 3) it convert input value into string"
     And I should see "✔ 4) it convert input value into string"
 
+  Scenario: Positive match with Coduo matcher with trailing phpspec's test double arguments
+    Given the PhpSpecDataProviderExtension is enabled
+    When I write a spec "spec/Coduo/Date/DateRangeSpec.php" with following code
+    """
+<?php
+
+namespace spec\Coduo\Date;
+
+use PhpSpec\ObjectBehavior;
+
+use DateTime;
+
+class DateRangeSpec extends ObjectBehavior
+{
+    /**
+     *  @dataProvider positiveConversionExamples
+     */
+    function it_returns_a_formatted_date_range($inputValue, DateTime $date)
+    {
+        $this->beConstructedWith($inputValue, $date);
+
+        $date->format('Ymd')->willReturn('2035-10-28');
+
+        $this->getFormattedRange()->shouldBeLike('1985-10-26 - 2035-10-28');
+    }
+
+    public function positiveConversionExamples()
+    {
+        return array(
+            array(new \DateTime('1985-10-26')),
+        );
+    }
+}
+    """
+    And I write a class "src/Coduo/Date/DateRange.php" with following code
+    """
+<?php
+
+namespace Coduo\Date;
+
+class DateRange
+{
+    private $start;
+    private $end;
+
+    public function __construct($start, $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function getFormattedRange()
+    {
+        return $this->start->format('Y-m-d') . ' - ' . $this->end->format('Ymd');
+    }
+}
+    """
+    And I run phpspec
+    Then it should pass
+    And I should see "✔ returns a formatted date range"
+    And I should see "✔ 1) it returns a formatted date range"
+

--- a/spec/Coduo/PhpSpec/DataProvider/Annotation/ParserSpec.php
+++ b/spec/Coduo/PhpSpec/DataProvider/Annotation/ParserSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Coduo\PhpSpec\Annotation\DataProvider;
+namespace spec\Coduo\PhpSpec\DataProvider\Annotation;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/src/Coduo/PhpSpec/DataProvider/Runner/Maintainer/DataProviderMaintainer.php
+++ b/src/Coduo/PhpSpec/DataProvider/Runner/Maintainer/DataProviderMaintainer.php
@@ -34,12 +34,17 @@ class DataProviderMaintainer implements MaintainerInterface
     {
         $exampleNum = $this->getExampleNumber($example->getTitle());
         $providedData = $this->getDataFromProvider($example);
+
         if (! array_key_exists($exampleNum, $providedData)) {
             return ;
         }
 
         $data = $providedData[$exampleNum];
+
         foreach ($example->getFunctionReflection()->getParameters() as $position => $parameter) {
+            if (!isset($data[$position])) {
+                continue;
+            }
             $collaborators->set($parameter->getName(), $data[$position]);
         }
     }
@@ -85,7 +90,7 @@ class DataProviderMaintainer implements MaintainerInterface
 
         $exampleParamsCount = count($example->getFunctionReflection()->getParameters());
         foreach ($providedData as $dataRow) {
-            if (!is_array($dataRow) || count($dataRow) != $exampleParamsCount) {
+            if (!is_array($dataRow)) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR enables the opportunity to inject the prophecy test doubles after the data provider ones.